### PR TITLE
Fixes to URL testing

### DIFF
--- a/uri.lisp
+++ b/uri.lisp
@@ -29,7 +29,7 @@
 
 (defun pchar-p (char)
   (or (unreserved-character-p char)
-      (sub-delimiter-p char)
+      (reserved-character-p char)
       (percent-encoded-p char)
       (find char ":@" :test #'char=)))
 
@@ -146,7 +146,7 @@
     (ratification-error path "Path must be at least one character long."))
   (loop for char across path
         unless (pchar-p char)
-          do (ratification-error path "Invalid character ~a. Path can only contain alphanumerics or ! $ & ' ( ) * + , ; = - . _ ~~ : @"))) ;
+          do (ratification-error path "Invalid character ~a. Path can only contain alphanumerics or ! $ & ' ( ) * + , ; = - . _ ~~ : @" char))) ;
 
 (define-test absolute-path (path)
   "Tests for a valid absolute path.

--- a/url.lisp
+++ b/url.lisp
@@ -46,11 +46,11 @@
   "Tests for a valid URL.
 
  (<protocol>://)?(<domain>)?<absolute-path>(\?<query>)?(#<fragment>)?"
-  (or
-   (cl-ppcre:register-groups-bind (NIL protocol domain path NIL query NIL fragment) ("^(([^:]+)://)?([^/]+)?(/[^\\?]+)(\\?([^#]*))?(\\#(.*))?$" url)
-     (when protocol (test-protocol protocol))
-     (when domain (test-domain domain))
-     (when path (test-absolute-path path))
-     (when query (test-query query))
-     (when fragment (test-fragment fragment)))
-   (ratification-error url "an URL must at the very least consist of a path.")))
+  (cl-ppcre:register-groups-bind (NIL protocol domain path NIL query NIL fragment) ("^(([^:]+)://)?([^/]+)?(/[^\\?]+)(\\?([^#]*))?(\\#(.*))?$" url)
+    (when protocol (test-protocol protocol))
+    (when domain (test-domain domain))
+    (when path (test-absolute-path path))
+    (when query (test-query query))
+    (when fragment (test-fragment fragment))
+    (unless path ;; With "http://www.google.com" above regex considers "http" as domain and "//www.google.com" as path
+      (ratification-error url "An URL must at the very least consist of a path."))))


### PR DESCRIPTION
There were two issues. 
First issue was when testing path it considered / as an illegal character because delimiter characters weren't tested, only sub-delimiters.
Second issue was when URL had no fragments the body of CL-PPCRE:R-G-B would return NIL and thus trigger the error.
