### PR TITLE
Avoid error in test-domain when checking email addresses without a domain

### DIFF
--- a/email.lisp
+++ b/email.lisp
@@ -42,4 +42,6 @@
 <local-part>@<domain>"
   (let ((atpos (email-atpos email start end)))
     (test-local-part email 0 atpos)
+    (unless (< (1+ atpos) end)
+      (ratification-error email "No domain found."))
     (test-domain email (1+ atpos) end)))


### PR DESCRIPTION
If an email address doesn't have a domain (such as "a@") then start in test-domain is out of bounds when calling (aref domain start).